### PR TITLE
Add documentation getting started code-sample

### DIFF
--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -38,3 +38,58 @@ landing_getting_started_1: |-
     },
   };
   </script>
+getting_started_front_end_integration_md: |-
+  The following example uses [Vue 2](https://vuejs.org/), the second major release of a JavaScript framework for building web user interfaces.
+
+  ```html
+  <!DOCTYPE html>
+  <html lang="en">
+
+  <head>
+    <meta charset="utf-8" />
+    <link rel="stylesheet"
+      href="https://cdn.jsdelivr.net/npm/@meilisearch/instant-meilisearch/templates/basic_search.css" />
+  </head>
+
+  <body>
+    <div id="app" class="wrapper">
+      <ais-instant-search :search-client="searchClient" index-name="movies">
+        <ais-configure :hits-per-page.camel="10" />
+        <ais-search-box placeholder="Search here…" class="searchbox"></ais-search-box>
+        <ais-hits>
+          <div slot="item" slot-scope="{ item }">
+            <ais-highlight :hit="item" attribute="title" />
+          </div>
+        </ais-hits>
+      </ais-instant-search>
+    </div>
+  </body>
+  <script src="https://cdn.jsdelivr.net/npm/vue@2.6.14"></script>
+  <script src="https://cdn.jsdelivr.net/npm/vue-instantsearch/vue2/umd/index.js"></script>
+  <script
+    src="https://cdn.jsdelivr.net/npm/@meilisearch/instant-meilisearch/dist/instant-meilisearch.umd.min.js"></script>
+  <script>
+    Vue.use(VueInstantSearch)
+    var app = new Vue({
+      el: '#app',
+      data: {
+        searchClient: instantMeiliSearch('http://127.0.0.1:7700')
+      }
+    })
+  </script>
+
+  </html>
+  ```
+
+  Here's what's happening:
+
+  - To use `instant-meilisearch` with Vue, you must add `<ais-instant-search>`, `<ais-search-box>`, and `<ais-hits>` to your application's HTML. These components are mandatory when generating the`instant-meilisearch` interface
+  - Other Vue components such as `<ais-configure>` and `<ais-highlight>` are optional. They offer greater control over `instant-meilisearch`'s behavior and appearance
+  - The first two`<script src="..">` tags import libraries needed to run `instant-meilisearch` with Vue
+  - The third and final `<script>` creates a new Vue instance and instructs it to use `instant-meilisearch`
+
+  :::note
+
+  The above example uses Vue 2. Refer to [this GitHub issue](https://github.com/meilisearch/meilisearch-vue/issues/102) to learn more about Vue 3.
+
+  :::


### PR DESCRIPTION
Add the code-sample of meilisearch-vue directly in this repo instead of in the documentation repo.
This mean we now need to maintain this code sample as well as the code sample present in the landing page.