### PR TITLE
Add explaination on vue3 sample

### DIFF
--- a/.code-samples-vue-3.meilisearch.yaml
+++ b/.code-samples-vue-3.meilisearch.yaml
@@ -101,7 +101,7 @@ getting_started_front_end_integration_md: |-
   ```
 
   Here's what's happening:
-  - To use `instant-meilisearch` with Vue, you must add `<ais-instant-search>`, `<ais-search-box>`, and `<ais-hits>` to your application's HTML. These components are mandatory when generating the`instant-meilisearch` interface
+  - To use `instant-meilisearch` with Vue, you must add `<ais-instant-search>`, `<ais-search-box>`, and `<ais-hits>` to your application's HTML. These components are mandatory when generating the `instant-meilisearch` interface
   - Other Vue components such as `<ais-configure>` and `<ais-highlight>` are optional. They offer greater control over `instant-meilisearch`'s behavior and appearance
   - The three `<script src="..">` tags import libraries needed to run `instant-meilisearch` with Vue
   - The fourth and final `<script>` creates a new Vue instance and instructs it to use `instant-meilisearch`

--- a/.code-samples-vue-3.meilisearch.yaml
+++ b/.code-samples-vue-3.meilisearch.yaml
@@ -103,5 +103,5 @@ getting_started_front_end_integration_md: |-
   Here's what's happening:
   - To use `instant-meilisearch` with Vue, you must add `<ais-instant-search>`, `<ais-search-box>`, and `<ais-hits>` to your application's HTML. These components are mandatory when generating the`instant-meilisearch` interface
   - Other Vue components such as `<ais-configure>` and `<ais-highlight>` are optional. They offer greater control over `instant-meilisearch`'s behavior and appearance
-  - The three two`<script src="..">` tags import libraries needed to run `instant-meilisearch` with Vue
+  - The three `<script src="..">` tags import libraries needed to run `instant-meilisearch` with Vue
   - The fourth and final `<script>` creates a new Vue instance and instructs it to use `instant-meilisearch`

--- a/.code-samples-vue-3.meilisearch.yaml
+++ b/.code-samples-vue-3.meilisearch.yaml
@@ -40,7 +40,7 @@ landing_getting_started: |-
   </script>
 
 getting_started_front_end_integration_md: |-
-  The following example uses [Vue 3](https://vuejs.org/) a JavaScript framework for building web user interfaces.
+  The following example uses [Vue 3](https://vuejs.org/), a JavaScript framework for building web user interfaces.
 
   ```html
   <!DOCTYPE html>

--- a/.code-samples-vue-3.meilisearch.yaml
+++ b/.code-samples-vue-3.meilisearch.yaml
@@ -39,9 +39,8 @@ landing_getting_started: |-
   };
   </script>
 
-
 getting_started_front_end_integration_md: |-
-  The following example uses [Vue 3](https://vuejs.org/).
+  The following example uses [Vue 3](https://vuejs.org/) a JavaScript framework for building web user interfaces.
 
   ```html
   <!DOCTYPE html>
@@ -100,3 +99,9 @@ getting_started_front_end_integration_md: |-
 
   </html>
   ```
+
+  Here's what's happening:
+  - To use `instant-meilisearch` with Vue, you must add `<ais-instant-search>`, `<ais-search-box>`, and `<ais-hits>` to your application's HTML. These components are mandatory when generating the`instant-meilisearch` interface
+  - Other Vue components such as `<ais-configure>` and `<ais-highlight>` are optional. They offer greater control over `instant-meilisearch`'s behavior and appearance
+  - The three two`<script src="..">` tags import libraries needed to run `instant-meilisearch` with Vue
+  - The fourth and final `<script>` creates a new Vue instance and instructs it to use `instant-meilisearch`

--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -39,7 +39,7 @@ landing_getting_started_1: |-
   };
   </script>
 getting_started_front_end_integration_md: |-
-  The following example uses [Vue 2](https://vuejs.org/), the second major release of Vue, a JavaScript framework for building web user interfaces. An example using Vue 3 is coming soon.
+  The following example uses [Vue 2](https://vuejs.org/), the second major release of Vue, a JavaScript framework for building web user interfaces.
 
   ```html
   <!DOCTYPE html>


### PR DESCRIPTION
Add missing explaination on vue3 code samples and remove the notification that a vue3 example is on its way